### PR TITLE
Increased left margin for charts

### DIFF
--- a/src/containers/charts/GradeDistributionChart.js
+++ b/src/containers/charts/GradeDistributionChart.js
@@ -87,7 +87,7 @@ class GradeDistributionChart extends Component {
           </div>
           <div style={{flex: 1}}>
             <ResponsiveContainer width='100%' aspect={16.0/9.0}>
-              <BarChart data={data} margin={{ top: 15, right: 5, left: -15, bottom: 20 }}>
+              <BarChart data={data} margin={{ top: 35, right: 5, left: 0, bottom: 20 }}>
                 <XAxis dataKey='name'>
                 </XAxis>
                 <YAxis domain={[0, 100]} tickCount={11}>


### PR DESCRIPTION
Fixes #8 

Increased left margin of grade distribution from `-15` to `0`.


![madgrades-2018-11-14t04_03_22 181z](https://user-images.githubusercontent.com/17896701/48459653-9ff8f500-e790-11e8-948c-c2bbacae1bf4.png)
