### PR TITLE
add UW Course Map to featured projects

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -56,6 +56,13 @@ const Home = () => {
           </Header>
 
           <PromoCard
+            title="UW Course Map"
+            description="Visualize course prerequisites with an interactive graph. Explore 10,000+ courses, view detailed course info, and check professor ratings all in one place."
+            link="https://uwcourses.com"
+            dateAdded="2025-11-24"
+          />
+
+          <PromoCard
             title="EnrollAlert"
             description="Get notified instantly when seats open up in your courses. Real-time updates synced with UW Course Search & Enroll give you peace of mind and the best chance to snag that perfect class."
             link="https://enrollalert.com"


### PR DESCRIPTION
I'm one of the creators of [uwcourses.com](https://uwcourses.com), I was wondering if Madgrades would be open to featuring us on the students projects section? We actually use Madgrades to pull historical grade data, and we're also open source https://github.com/twangodev/uw-coursemap