### PR TITLE
Fixed flash when load dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,27 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="shortcut icon" href="/favicon.ico" />
     <title>Madgrades</title>
+      <style>
+          :root {
+              --bg-primary: #ffffff;
+              --text-primary: rgba(0, 0, 0, 0.87);
+          }
+
+          [data-theme="dark"] {
+              --bg-primary: #0a0a0a;
+              --text-primary: rgba(255, 255, 255, 0.9);
+          }
+
+          body {
+              background-color: var(--bg-primary);
+              color: var(--text-primary);
+              margin: 0;
+          }
+
+          .preload, .preload * {
+              transition: none !important;
+          }
+      </style>
     <meta
       name="description"
       content="Search and visualize University of Wisconsin Madison (UW Madison) course grade distributions."
@@ -53,6 +74,22 @@
   </head>
 
   <body>
+    <script>
+      (function() {
+          try {
+              document.documentElement.classList.add('preload');
+              let storageKey = 'madgrades-theme';
+              let classNameDark = 'dark';
+              let localTheme = localStorage.getItem(storageKey);
+              let systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+
+              if (localTheme === classNameDark || (!localTheme && systemDark)) {
+                  document.documentElement.setAttribute('data-theme', classNameDark);
+              }
+          } catch (e) {}
+      })();
+    </script>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,8 @@ class App extends Component {
   componentDidMount() {
     // Set initial theme attribute
     document.documentElement.setAttribute("data-theme", this.props.theme);
+    setTimeout(() => {
+        document.documentElement.classList.remove('preload');}, 0);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -24,9 +24,6 @@ const store = createStore(
   ),
 );
 
-// Set initial theme attribute to prevent flash
-const savedTheme = localStorage.getItem("madgrades-theme") || "light";
-document.documentElement.setAttribute("data-theme", savedTheme);
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(


### PR DESCRIPTION
Happy to see dark mode was added to Madgrades.com!
As a dark theme user, I found and fixed two issues: 
The site will remain light background on initial load for a perceptible moment, and will replay the transition from light theme to dark when loading/refreshing the page.
Now the site can be smoothly loaded from a dark theme window.